### PR TITLE
Helppetf: 입양센터 기능 완성 :

### DIFF
--- a/src/main/java/com/tech/petfriends/admin/dto/AdminHelpPetfDto.java
+++ b/src/main/java/com/tech/petfriends/admin/dto/AdminHelpPetfDto.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 @Getter
 public class AdminHelpPetfDto {
 	private int hpt_seq;
-	private String hpt_yt_url;
 	private String hpt_yt_videoid;
 	private String hpt_exp;
 	private String hpt_title;

--- a/src/main/java/com/tech/petfriends/admin/mapper/AdminPageDao.java
+++ b/src/main/java/com/tech/petfriends/admin/mapper/AdminPageDao.java
@@ -13,7 +13,7 @@ public interface AdminPageDao {
 
 	AdminHelpPetfDto adminPetteacherDetail(String hpt_seq);
 
-	void adminPetteacherWrite(String hpt_title, String hpt_exp, String hpt_content, String hpt_yt_url, String hpt_yt_videoid,
+	void adminPetteacherWrite(String hpt_title, String hpt_exp, String hpt_content, String hpt_yt_videoid,
 			String hpt_pettype, String hpt_category);
 
 	void adminPetteacherDelete(String hpt_seq);

--- a/src/main/java/com/tech/petfriends/admin/service/AdminPetteacherWriteService.java
+++ b/src/main/java/com/tech/petfriends/admin/service/AdminPetteacherWriteService.java
@@ -24,12 +24,11 @@ public class AdminPetteacherWriteService implements AdminServiceInterface {
 		String hpt_exp = request.getParameter("hpt_exp");
 		String hpt_content = request.getParameter("hpt_content");
 		String hpt_yt_videoid = request.getParameter("hpt_yt_videoid");
-		String hpt_yt_url = "https://www.youtube.com/embed/" + hpt_yt_videoid;
 		String hpt_pettype = request.getParameter("hpt_pettype");
 		String hpt_category = request.getParameter("hpt_category");
 
 		adminDao.adminPetteacherWrite(hpt_title, hpt_exp, hpt_content, 
-				hpt_yt_url, hpt_yt_videoid, hpt_pettype, hpt_category);
+				hpt_yt_videoid, hpt_pettype, hpt_category);
 	}
 
 }

--- a/src/main/java/com/tech/petfriends/helppetf/controller/HelpPetfRestController.java
+++ b/src/main/java/com/tech/petfriends/helppetf/controller/HelpPetfRestController.java
@@ -31,15 +31,9 @@ public class HelpPetfRestController {
 	@GetMapping("/adoption/getJson")
 	public Mono<ResponseEntity<HelpPetfAdoptionItemsVo>> adoptionGetJson(HttpServletRequest request, Model model) throws Exception {
 		model.addAttribute("request", request);
-		return adoptionService.fetchAdoptionDataMain(model);
+		return adoptionService.fetchAdoptionData(model);
 	}
 	
-	@GetMapping("/adoption/getFilterJson")
-	public Mono<ResponseEntity<HelpPetfAdoptionItemsVo>> adoptionGetFilterJson(HttpServletRequest request, Model model) throws Exception {
-		model.addAttribute("request", request);
-		return adoptionService.fetchAdoptionDataFilter(model);
-	}
-
 	@PostMapping("/adoption/adoption_data")
 	public String adoptionData(@RequestBody AdoptionSelectedAnimalDto adoptionSelectedDto, HttpServletRequest request) {
 		// adoption_main에서 호출한 함수로 인해 작동

--- a/src/main/java/com/tech/petfriends/helppetf/mapper/HelpPetfDao.java
+++ b/src/main/java/com/tech/petfriends/helppetf/mapper/HelpPetfDao.java
@@ -14,4 +14,6 @@ public interface HelpPetfDao {
 	public ArrayList<HelpPetfDto> petteacherList();
 
 	public String findUserAddr(String userId);
+
+	public void upViews(String hpt_seq);
 }

--- a/src/main/java/com/tech/petfriends/helppetf/service/AdoptionGetJson.java
+++ b/src/main/java/com/tech/petfriends/helppetf/service/AdoptionGetJson.java
@@ -23,168 +23,122 @@ import reactor.core.publisher.Mono;
 
 @Service
 public class AdoptionGetJson {
-    
+
 	// WebClient는 비동기적으로 HTTP 요청을 보내기 위해 사용되는 스프링 WebFlux의 클라이언트이다.
 	private final WebClient webClient;
 
 	@Autowired // api key 주입
 	ApikeyConfig apikeyConfig;
-	
+
 	public AdoptionGetJson(final WebClient webClient) {
 		this.webClient = webClient;
 	}
-	
+
 	/**
 	 * 이 메서드는 API로부터 데이터를 비동기적으로 가져옴
 	 * 
 	 * @return ResponseEntity<HelpPetfAdoptionItemsVo> JSON 응답을 포함한 ResponseEntity
 	 * @throws Exception 예외 발생 시
 	 */
-	public Mono<ResponseEntity<HelpPetfAdoptionItemsVo>> fetchAdoptionDataMain(Model model) throws Exception {
-		
+	public Mono<ResponseEntity<HelpPetfAdoptionItemsVo>> fetchAdoptionData(Model model) throws Exception {
+
 		Map<String, Object> map = model.asMap();
 		HttpServletRequest request = (HttpServletRequest) map.get("request");
-		
-//		request.getParameter("pageNo");
-		System.out.println(request.getParameter("pageNo"));
+
 		// api 요청주소 End point
 		String baseUrl = "https://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic";
-		
+
 		// api serviceKey
 		String apikey = "?serviceKey=" + apikeyConfig.getOpenDataApikey();
 		String pageNo = "&pageNo=" + request.getParameter("pageNo");
-		String numOfRows = "&numOfRows=" + "80";
-		String _type = "&_type=" + "json";
-		String extraParam = pageNo + numOfRows + _type;
-		String addParameters = apikey + extraParam;	
-		
-		System.out.println(addParameters);
-		/**
-		 * 비동기적으로 JSON 데이터를 API로부터 받아옴
-		 * Mono 객체를 리턴
-		 * 리액티브 프로그래밍에서 비동기적으로 반환되는 하나의 데이터 스트림을 의미함
-		 * 
-		 * 설명:
-		 * .get() : http get 요청 보냄
-		 * .retrieve() : 서버로부터 응답 받아옴
-		 * .onStatus() : 4xx, 5xx 오류일 시 예외 발생
-		 * .bodyToMono(String.class) : 응답 본문을 String으로 받음
-		 * 
-		 * * 파싱 -> .map(json -> ... )}  
-		 * 		: parsingJsonObject() 메서드 호출하여 json을 HelpPetfAdoptionItemsVo타입으로 변환
-		 *  변환 성공 - ResponseEntity 객체를 생성하여 성공 상태(HttpStatus.OK)와 함께 반환
-		 *  예외 발생시 - 빈 리스트를 가진 HelpPetfAdoptionItemsVo를 생성하고, 내부 서버 오류 상태로 반환
-		 *  
-		 *  .onErrorReturn(...) : 요청 중 에러가 발생할 경우, INTERNAL_SERVER_ERROR 상태와 함께 에러 메시지를 반환
-		 */
-		return webClient.get().uri(baseUrl + addParameters).retrieve()
-				.onStatus(HttpStatus::is4xxClientError, clientResponse -> Mono.error(new Exception("Client Error")))
-	            .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new Exception("Server Error")))
-	            .bodyToMono(String.class)  // JSON 데이터를 문자열로 받음
-	            .retry(3)
-	            .map(json -> {
-	            	HelpPetfAdoptionItemsVo adoptionItems;
-					try { // try: json 파싱
-						adoptionItems = parsingJsonObject(json, HelpPetfAdoptionItemsVo.class);
-						return new ResponseEntity<>(adoptionItems, HttpStatus.OK);
-					} catch (Exception e) {
-						e.printStackTrace();
-						return new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()), HttpStatus.INTERNAL_SERVER_ERROR);
-					}
-	            })
-	            .onErrorReturn(new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()), HttpStatus.INTERNAL_SERVER_ERROR));
-	}
-	
-	// 필터링시의 데이터
-	public Mono<ResponseEntity<HelpPetfAdoptionItemsVo>> fetchAdoptionDataFilter(Model model) {
-		Map<String, Object> map = model.asMap();
-		HttpServletRequest request = (HttpServletRequest) map.get("request");
-		/** 요청 변수
-		* serviceKey = API key
-		* upr_cd = 시도코드 (시도 조회 OPEN API 참조)
-		* org_cd = 시군구코드 (시군구 조회 OPEN API 참조)
-		* upkind = 축종코드 (요청파라미터 에서는 k가 소문자이지만, 변수이름은 upKind로 작성하였음) (개 : 417000, 고양이 : 422400, 기타 : 429900)
-		* kind = 품종코드 (품종 조회 OPEN API 참조)
-		*/
-		// api 요청주소 End point
-		String baseUrl = "https://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic";
-		
-		// api serviceKey
-		String apikey = "?serviceKey=" + apikeyConfig.getOpenDataApikey();
-		
+
 		// parameter 값
 		String upr_cd = setValueOfParam(request, "upr_cd");
 		String org_cd = setValueOfParam(request, "org_cd");
 		String upKind = setValueOfParam(request, "upKind");
 		String kind = setValueOfParam(request, "kind");
-		String extraParam = "&pageNo=1&numOfRows=80&_type=json";
-		
-		// 값이 다 있다면 addParameter는 "?serviceKey=APIKEY&upr_cd=00&org_cd=00&upKind=00&kind=00 와 같은 형식이다.
+
+		String numOfRows = "&numOfRows=" + "80";
+		String _type = "&_type=" + "json";
+		String extraParam = pageNo + numOfRows + _type;
 		String addParameters = apikey + upr_cd + org_cd + upKind + kind + extraParam;
+
+		/**
+		 * 비동기적으로 JSON 데이터를 API로부터 받아옴 Mono 객체를 리턴 리액티브 프로그래밍에서 비동기적으로 반환되는 하나의 데이터 스트림을
+		 * 의미함
+		 * 
+		 * 설명: .get() : http get 요청 보냄 .retrieve() : 서버로부터 응답 받아옴 .onStatus() : 4xx, 5xx
+		 * 오류일 시 예외 발생 .bodyToMono(String.class) : 응답 본문을 String으로 받음
+		 * 
+		 * * 파싱 -> .map(json -> ... )} : parsingJsonObject() 메서드 호출하여 json을
+		 * HelpPetfAdoptionItemsVo타입으로 변환 변환 성공 - ResponseEntity 객체를 생성하여 성공
+		 * 상태(HttpStatus.OK)와 함께 반환 예외 발생시 - 빈 리스트를 가진 HelpPetfAdoptionItemsVo를 생성하고, 내부
+		 * 서버 오류 상태로 반환
+		 * 
+		 * .onErrorReturn(...) : 요청 중 에러가 발생할 경우, INTERNAL_SERVER_ERROR 상태와 함께 에러 메시지를
+		 * 반환
+		 */
 		return webClient.get().uri(baseUrl + addParameters).retrieve()
 				.onStatus(HttpStatus::is4xxClientError, clientResponse -> Mono.error(new Exception("Client Error")))
-	            .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new Exception("Server Error")))
-	            .bodyToMono(String.class)  // JSON 데이터를 문자열로 받음
-	            .retry(3)
-	            .map(json -> {
-	            	HelpPetfAdoptionItemsVo adoptionItems;
+				.onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new Exception("Server Error")))
+				.bodyToMono(String.class) // JSON 데이터를 문자열로 받음
+				.retry(3).map(json -> {
+					HelpPetfAdoptionItemsVo adoptionItems;
 					try { // try: json 파싱
 						adoptionItems = parsingJsonObject(json, HelpPetfAdoptionItemsVo.class);
 						return new ResponseEntity<>(adoptionItems, HttpStatus.OK);
 					} catch (Exception e) {
 						e.printStackTrace();
-						return new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()), HttpStatus.INTERNAL_SERVER_ERROR);
+						return new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()),
+								HttpStatus.INTERNAL_SERVER_ERROR);
 					}
-	            })
-	            .onErrorReturn(new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()), HttpStatus.INTERNAL_SERVER_ERROR));
+				}).onErrorReturn(
+						new ResponseEntity<>(new HelpPetfAdoptionItemsVo(List.of()), HttpStatus.INTERNAL_SERVER_ERROR));
 	}
-	
+
 	private String setValueOfParam(HttpServletRequest request, String paramName) {
-		/** 
-		 * "paramName"의 value가 "any"가 아니라면 get 메소드의 파라미터 형식으로 설정 - any라면 공백설정
-		 * paramName, paramValue는 adoption_main.jsp에서 form 내부의 select 태그를 선택 후
-		 * "검색" 버튼을 클릭했을 때 전달되는 파라미터이다.
+		/**
+		 * "paramName"의 value가 "any"가 아니라면 get 메소드의 파라미터 형식으로 설정 - any라면 공백설정 paramName,
+		 * paramValue는 adoption_main.jsp에서 form 내부의 select 태그를 선택 후 "검색" 버튼을 클릭했을 때 전달되는
+		 * 파라미터이다.
 		 */
-	    String paramValue = request.getParameter(paramName);
-	    return (paramValue != null && !paramValue.equals("any")) ? "&" + paramName + "=" + paramValue : "";
+		String paramValue = request.getParameter(paramName);
+		return (paramValue != null && !paramValue.equals("any")) ? "&" + paramName + "=" + paramValue : "";
 	}
-	
+
 	// 제너릭 메서드 선언: <T>
-	/* 설명: 
+	/*
+	 * 설명:
 	 * 
-	 * 이 메서드는 제네릭을 사용하여 다양한 타입의 객체로 변환할 수 있다 
-	 * <T>는 제네릭 타입 파라미터를 의미하며, 메서드가 반환하는 타입을 지정함.
-	 * 		=> 이 메서드는 호출 시점에 전달된 valueType 클래스에 맞춰서 JSON 문자열을 해당 객체로 변환
-	 * 반환형은 T로, 호출할 때 전달한 클래스 타입에 따라 달라짐
+	 * 이 메서드는 제네릭을 사용하여 다양한 타입의 객체로 변환할 수 있다 <T>는 제네릭 타입 파라미터를 의미하며, 메서드가 반환하는 타입을
+	 * 지정함. => 이 메서드는 호출 시점에 전달된 valueType 클래스에 맞춰서 JSON 문자열을 해당 객체로 변환 반환형은 T로, 호출할
+	 * 때 전달한 클래스 타입에 따라 달라짐
 	 * 
-	 * 메서드 매개변수:
-	 * String json: 변환하려는 JSON 문자열
-	 * Class<T> valueType: JSON 데이터를 변환할 객체의 타입을 나타내는 클래스
-	 * EX) HelpPetAdoptionItemsVo.class처럼 특정 클래스의 타입을 전달
+	 * 메서드 매개변수: String json: 변환하려는 JSON 문자열 Class<T> valueType: JSON 데이터를 변환할 객체의
+	 * 타입을 나타내는 클래스 EX) HelpPetAdoptionItemsVo.class처럼 특정 클래스의 타입을 전달
 	 * 
-	 * ObjectMapper:
-	 * ObjectMapper는 Jackson 라이브러리의 클래스이다. JSON 데이터를 Java 객체로 변환하거나 그 반대로 변환하는 데 사용함.
-	 * 여기서 사용된 mapper.readValue(json, valueType)는 JSON 문자열을 지정된 클래스 타입으로 변환하는 역할을 함.
+	 * ObjectMapper: ObjectMapper는 Jackson 라이브러리의 클래스이다. JSON 데이터를 Java 객체로 변환하거나 그
+	 * 반대로 변환하는 데 사용함. 여기서 사용된 mapper.readValue(json, valueType)는 JSON 문자열을 지정된 클래스
+	 * 타입으로 변환하는 역할을 함.
 	 * 
 	 * 
 	 */
 	<T> T parsingJsonObject(String json, Class<T> valueType) throws Exception {
 		// 예시) HelpPetfAdoptionItemsVo에 json value의 Object 형식을 매핑해 return
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            T result = mapper.readValue(json, valueType);
-            return result;
-        } catch (ValueInstantiationException e) {
-            throw new Exception("Failed to instantiate the class: " + valueType.getName(), e);
-        } catch (JsonParseException e) {
-            throw new Exception("JSON parse error: " + e.getMessage(), e);
-        } catch (JsonMappingException e) {
-            throw new Exception("JSON mapping error: " + e.getMessage(), e);
-        } catch (Exception e) {
-            throw new Exception("General error while parsing JSON: " + e.getMessage(), e);
-        }
-    
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			T result = mapper.readValue(json, valueType);
+			return result;
+		} catch (ValueInstantiationException e) {
+			throw new Exception("Failed to instantiate the class: " + valueType.getName(), e);
+		} catch (JsonParseException e) {
+			throw new Exception("JSON parse error: " + e.getMessage(), e);
+		} catch (JsonMappingException e) {
+			throw new Exception("JSON mapping error: " + e.getMessage(), e);
+		} catch (Exception e) {
+			throw new Exception("General error while parsing JSON: " + e.getMessage(), e);
+		}
+
 	}
 
-	
 }

--- a/src/main/java/com/tech/petfriends/helppetf/service/PetteacherDetailService.java
+++ b/src/main/java/com/tech/petfriends/helppetf/service/PetteacherDetailService.java
@@ -26,6 +26,8 @@ public class PetteacherDetailService implements HelppetfServiceInter {
 		HttpServletRequest request = (HttpServletRequest) map.get("request");
 		
 		String hpt_seq = request.getParameter("hpt_seq");
+		// 조회수 +1
+		helpDao.upViews(hpt_seq);
 		HelpPetfDto dto = helpDao.petteacherDetail(hpt_seq);
 		
 		model.addAttribute("dto", dto);

--- a/src/main/resources/mybatis/mapper/AdminHelppetfDao.xml
+++ b/src/main/resources/mybatis/mapper/AdminHelppetfDao.xml
@@ -13,9 +13,9 @@
 	</select>
 	<insert id="adminPetteacherWrite">
 		INSERT INTO HELP_PETTEACHER VALUES
-		(SEQ_HPT.NEXTVAL, #{hpt_yt_url},
-		 #{hpt_yt_videoid}, #{hpt_exp}, #{hpt_title}, #{hpt_content}, 
-		 #{hpt_pettype}, #{hpt_category}, 0, SYSDATE)
+		(SEQ_HPT.NEXTVAL, #{hpt_yt_videoid}, 
+		#{hpt_exp}, #{hpt_title}, #{hpt_content}, 
+		#{hpt_pettype}, #{hpt_category}, 0, SYSDATE)
 	</insert>
 	<delete id="adminPetteacherDelete">
 		DELETE FROM HELP_PETTEACHER WHERE HPT_SEQ = #{hpt_seq}

--- a/src/main/resources/mybatis/mapper/HelpPetfDao.xml
+++ b/src/main/resources/mybatis/mapper/HelpPetfDao.xml
@@ -6,9 +6,14 @@
 	<select id="petteacherList" resultType="com.tech.petfriends.helppetf.dto.HelpPetfDto">
 		SELECT * FROM HELP_PETTEACHER
 	</select>
+	<update id="upViews">
+		UPDATE HELP_PETTEACHER 
+		SET HPT_HIT = HPT_HIT + 1 
+		WHERE HPT_SEQ = #{hpt_seq}
+	</update>
 	<select id="petteacherDetail" resultType="com.tech.petfriends.helppetf.dto.HelpPetfDto">
 		SELECT * FROM HELP_PETTEACHER 
-		WHERE HPT_SEQ = #{param1}
+		WHERE HPT_SEQ = #{hpt_seq}
 	</select>
 	<select id="findUserAddr" resultType="String">
 		SELECT TEMP_ADDR 

--- a/src/main/resources/static/js/helppetf/adoption_main.js
+++ b/src/main/resources/static/js/helppetf/adoption_main.js
@@ -15,25 +15,24 @@ $(document).ready(function() {
 	const itemsPerPage = 8; // 페이지 당 item 수 = 8
 	let currentPage = 1; // 현재 표시되는 페이지
 	let totalItems = 0; // 총 item 수 초기화
-	let totalPages = 0; // 총 페이지 수
 	let adoptionItems = []; // item들을 담을 배열
 	let currPageGroup = 1; // 현재 페이지 그룹
+	let preEndPage = 0; // 이전 페이지의 마지막 페이지 번호
+	let formParam = ''; // form (필터) 의 파라미터값
+	fetchData(currentPage, currPageGroup, formParam); // 페이지 로드 시 호출 (formParam은 공백: 필터가 없으므로)
 
-	fetchData(currentPage, currPageGroup); // 페이지 로드 시 기본 페이지 호출
-
-	function fetchData(currentPage, currPageGroup) {
+	function fetchData(currentPage, currPageGroup, formParam) {
 		$.ajax({
-			url: '/helppetf/adoption/getJson?pageNo=' + currPageGroup, // pageNo에 맞는 데이터 요청
+			url: '/helppetf/adoption/getJson?pageNo=' + currPageGroup + '&' + formParam, // pageNo에 맞는 데이터 요청-필터링된 API 호출 
 			method: 'GET',
 			dataType: 'json',
 			headers: {
-				'Cache-Control': 'no-cache'
+				'Cache-Control': 'no-cache' // 캐시 없음 설정
 			},
 			success: function(data) {
-				adoptionItems = data.item;
+				adoptionItems = data.item; // 배열에 아이템 대입
 				totalItems = adoptionItems.length; // 받아온 데이터에서 총 item 수 계산
 				totalPages = Math.ceil(totalItems / itemsPerPage); // 총 페이지 수 계산
-				console.log(currentPage, currPageGroup);
 				displayItems(currentPage); // 아이템 표시
 				setupPagination(currentPage, currPageGroup); // 페이지네이션 설정
 			},
@@ -43,42 +42,35 @@ $(document).ready(function() {
 		});
 	}
 
-	// 필터링 후 검색 버튼을 누를 때의 API 호출
-	$('#filterSubmit').on('click', function() {
-		const formParam = $('#filter_form form').serialize();
-		filterData(currentPage);
-
-		function filterData(currentPage, currPageGroup) {
-			$.ajax({
-				url: '/helppetf/adoption/getFilterJson?pageNo=' + currPageGroup + '&' + formParam, // 필터링된 API 호출
-				method: 'GET',
-				dataType: 'json',
-				headers: {
-					'Cache-Control': 'no-cache',
-				},
-				success: function(data) {
-					adoptionItems = data.item;
-					totalItems = adoptionItems.length;
-					displayItems(currentPage);
-					setupPagination(currentPage, currPageGroup);
-				},
-				error: function(xhr, status, error) {
-					console.error('Error fetching data:', error);
-				},
-			});
-		}
+	// 필터 선택 후 filterSubmit 클릭 시 호출
+	$('#filterSubmit').on('click', function(event) {
+		event.preventDefault(); // 기본 form 제출 동작 방지 (기본 링크를 이것으로 대체함)
+		formParam = $('#filter_form form').serialize(); // form 데이터 시리얼라이즈
+		currentPage = 1; // 필터링 시 페이지를 1로 리셋
+		fetchData(currentPage, currPageGroup, formParam); // 필터 데이터를 포함해서 fetchData 호출
 	});
 
 	// 아이템을 페이지에 맞게 출력
 	function displayItems(currentPage) {
-		const start = (currentPage - 1) * itemsPerPage;
+		if (currentPage <= 10) {
+			// 현재 페이지가 10이하인 경우 == 페이지그룹이 1인 경우
+			var start = (currentPage - 1) * itemsPerPage;
+		} else { 
+			// 그 외 == 페이지그룹이 2이상인 경우
+			// start = (현재페이지 - 이전마지막페이지 - 1) * itemsPerPage(8)
+			var start = ((currentPage - preEndPage) - 1) * itemsPerPage;
+		}
+		
+		// end = 시작 인덱스번호 + itemsPerPage(8)
 		const end = start + itemsPerPage;
+		// .slice(start, end)는 배열에서 start부터 end 이전까지의 아이템들을 추출
+		// start가 0이고 end가 8이라면 인덱스 [0] ~ [7] 을 출력
 		const visibleItems = adoptionItems.slice(start, end);
-
 		// item 객체의 정보를 테이블로 출력
 		let cards = '';
 		$.each(visibleItems, function(index, item) {
-			cards += '<div class="adoption-card"><a href="#" class="adoption-link" data-index="' + (start + index) + '">';
+			// 인덱스가 0~79 이므로 페이지가 넘어가도 인덱스 번호가 정상적으로 불러와지도록 현재 페이지의 시작 인덱스 번호를 더해준다
+			cards += '<div class="adoption-card"><a href="#" class="adoption-link" data-index="' + (start + index) + '">'; 
 			cards += '<img src="' + item.popfile + '" alt="Pet Image" />';
 			cards += '<div class="content">';
 			cards += '<h3>' + item.kindCd + '</h3>';
@@ -100,19 +92,20 @@ $(document).ready(function() {
 		const index = $(this).data('index'); // 클릭한 요소의 인덱스 값을 가져옴
 		const selectedItem = adoptionItems[index]; // 선택된 항목 가져오기
 
-		// POST 요청 보내기
+		// API 요청이 아니라 이미 불러와진 데이터중 
+		// 클릭한 곳에 해당하는 데이터를 세션에 저장하여 데이터를 불러옴
 		fetch('/helppetf/adoption/adoption_data', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			body: JSON.stringify(selectedItem) // 선택된 객체를 JSON으로 변환
+			body: JSON.stringify(selectedItem) // 선택된 객체를 Json으로 변환
 		})
 			.then(response => {
 				if (!response.ok) {
-					throw new Error('Network response was not ok');
+					throw new Error('ERROR');
 				}
-				return response.json(); // 응답을 JSON으로 변환
+				return response.json(); // 응답을 Json으로 변환
 			})
 			.then(data => {
 				console.log('Success:', data);
@@ -128,7 +121,7 @@ $(document).ready(function() {
 	function setupPagination(currentPage, currPageGroup) {
 		const maxPagesToShow = 10; // 한 번에 보여줄 페이지 수
 		const startPage = (currPageGroup - 1) * maxPagesToShow + 1; // 현재 그룹의 첫 페이지 계산
-		const endPage = Math.min(startPage + maxPagesToShow - 1, totalPages); // 마지막 페이지 계산
+		const endPage = startPage + maxPagesToShow - 1; // 마지막 페이지 계산
 
 		let paginationHtml = '';
 
@@ -139,38 +132,38 @@ $(document).ready(function() {
 
 		// 페이지 번호 생성
 		for (let i = startPage; i <= endPage; i++) {
-			paginationHtml += '<a href="#" class="' + (i === currentPage ? 'active' : '') + '" data-page="' + i + '">' + i + '</a>';
+			paginationHtml += '<a href="#" id="i" class="' + (i === currentPage ? 'active' : '') + '" data-page="' + i + '">' + i + '</a>';
 		}
 
-		// 다음 버튼 추가 (전체 페이지 수가 현재 페이지 그룹의 마지막 페이지보다 클 경우 표시)
-		//if (endPage < totalPages) {
+		// 다음 버튼 추가
 		paginationHtml += '<a href="#" id="next-group">다음 &raquo;</a>';
-		//}
 
 		$('#pagination').html(paginationHtml);
 
 		// 페이지 클릭 이벤트 핸들러
-		   $('#pagination a').on('click', function(event) {
-		       event.preventDefault();
+		$('#pagination a').on('click', function(event) {
+			event.preventDefault();
 
-		       if ($(this).attr('id') === 'prev-group') {
-		           // 이전 그룹으로 이동
-		           currPageGroup--;
-		           currentPage = (currPageGroup - 1) * maxPagesToShow + 1; // 이전 그룹의 첫 페이지
-		       } else if ($(this).attr('id') === 'next-group') {
-		           // 다음 그룹으로 이동
-		           currPageGroup++;
-		           currentPage = (currPageGroup - 1) * maxPagesToShow + 1; // 다음 그룹의 첫 페이지
-		       } else {
-		           // 클릭한 페이지로 이동
-		           currentPage = $(this).data('page');
-		       }
-
-
-			// 페이지 번호와 그룹에 맞게 데이터 다시 로드
-			console.log(currentPage, currPageGroup)
-
-			fetchData(currentPage, currPageGroup);
+			if ($(this).attr('id') === 'prev-group') {
+				// 이전 그룹으로 이동
+				currPageGroup--;
+				currentPage = (currPageGroup - 1) * maxPagesToShow + 1; // 이전 그룹의 첫 페이지
+				preEndPage = endPage - 20;
+				fetchData(currentPage, currPageGroup, formParam);
+				displayItems(currentPage)
+			} else if ($(this).attr('id') === 'next-group') {
+				// 다음 그룹으로 이동
+				currPageGroup++;
+				currentPage = (currPageGroup - 1) * maxPagesToShow + 1; // 다음 그룹의 첫 페이지
+				preEndPage = endPage;
+				fetchData(currentPage, currPageGroup, formParam);
+				displayItems(currentPage)
+			} else /* if ($(this).attr('id') === $(this).data('page')) */ {
+				// 클릭한 페이지로 이동
+				currentPage = $(this).data('page');
+				displayItems(currentPage)
+				setupPagination(currentPage, currPageGroup)
+			}
 		});
 	}
 

--- a/src/main/webapp/WEB-INF/views/admin/admin_petteacher_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/admin_petteacher_detail.jsp
@@ -34,10 +34,6 @@
 			<td>${dto.hpt_content }</td>
 		</tr>
 		<tr>
-			<td>URL</td>
-			<td>${dto.hpt_yt_url }</td>
-		</tr>
-		<tr>
 			<td>Video ID</td>
 			<td>${dto.hpt_yt_videoid }</td>
 		</tr>
@@ -64,61 +60,61 @@
 			<td>
 				<!-- 1. 영상이 노출될 영역을 확보한다. 
     			 api가 제대로 작동하면 <div>에 자동으로 <iframe> 태그가 load될 것 이다. -->
-				<div id="player"></div> <script>
-					// 2. 이 코드는 Iframe Player API를 비동기적으로 로드한다. @필수
-					var tag = document.createElement('script');
-
-					tag.src = "https://www.youtube.com/iframe_api";
-					var firstScriptTag = document
-							.getElementsByTagName('script')[0];
-					firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-					// 3. API 코드를 다운로드 받은 다음에 <iframe>을 생성하는 기능 (youtube player도 더불어)
-					var v_id = '<c:out value="${dto.hpt_yt_videoid }" />';
-					var player;
-					function onYouTubeIframeAPIReady() {
-						player = new YT.Player('player', {
-							height : '360', //변경가능-영상 높이
-							width : '640', //변경가능-영상 너비
-							videoId : v_id, //변경-영상ID
-							playerVars : {
-								'rel' : 0, //연관동영상 표시여부(0:표시안함)
-								'controls' : 1, //플레이어 컨트롤러 표시여부(0:표시안함)
-								'autoplay' : 1, //자동재생 여부(1:자동재생 함, mute와 함께 설정)
-								'mute' : 1, //음소거여부(1:음소거 함)
-								'loop' : 0, //반복재생여부(1:반복재생 함)
-								'playsinline' : 1
-							//iOS환경에서 전체화면으로 재생하지 않게
-							/*  'playlist' : 'M7lc1UVf-VE'   //재생할 영상 리스트 */
-							},
-							events : {
-								'onReady' : onPlayerReady, //onReady 상태일 때 작동하는 function이름
-								'onStateChange' : onPlayerStateChange
-							//onStateChange 상태일 때 작동하는 function이름
-							}
-						});
-					}
-
-					// 4. API는 비디오 플레이어가 준비되면 아래의 function을 불러올 것이다.
-					function onPlayerReady(event) {
-						event.target.playVideo();
-					}
-
-					// 5. API는 플레이어의 상태가 변화될 때 아래의 function을 불러올 것이다.
-					//    이 function은 비디오가 재생되고 있을 때를 가르킨다.(state=1),
-					//    플레이어는 6초 이상 재생되고 정지되어야 한다.
-					var done = false;
-					function onPlayerStateChange(event) {
-						if (event.data == YT.PlayerState.PLAYING && !done) {
-							setTimeout(stopVideo, 6000);
-							done = true;
+				<div id="player"></div>
+					<script>
+						// 2. 이 코드는 Iframe Player API를 비동기적으로 로드한다. @필수
+						var tag = document.createElement('script');
+	
+						tag.src = "https://www.youtube.com/iframe_api";
+						var firstScriptTag = document
+								.getElementsByTagName('script')[0];
+						firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+	
+						// 3. API 코드를 다운로드 받은 다음에 <iframe>을 생성하는 기능 (youtube player도 더불어)
+						var v_id = '<c:out value="${dto.hpt_yt_videoid }" />';
+						var player;
+						function onYouTubeIframeAPIReady() {
+							player = new YT.Player('player', {
+								height : '360', //변경가능-영상 높이
+								width : '640', //변경가능-영상 너비
+								videoId : v_id, //변경-영상ID
+								playerVars : {
+									'rel' : 0, //연관동영상 표시여부(0:표시안함)
+									'controls' : 1, //플레이어 컨트롤러 표시여부(0:표시안함)
+							//		'autoplay' : 1, //자동재생 여부(1:자동재생 함, mute와 함께 설정)
+							//		'mute' : 1, //음소거여부(1:음소거 함)
+									'loop' : 0, //반복재생여부(1:반복재생 함)
+									'playsinline' : 1
+								//iOS환경에서 전체화면으로 재생하지 않게
+								/*  'playlist' : 'M7lc1UVf-VE'   //재생할 영상 리스트 */
+								},
+								events : {
+									'onReady' : onPlayerReady, //onReady 상태일 때 작동하는 function이름
+									'onStateChange' : onPlayerStateChange
+								//onStateChange 상태일 때 작동하는 function이름
+								}
+							});
 						}
-					}
-					function stopVideo() {
-						player.stopVideo();
-					}
+	
+						// 4. API는 비디오 플레이어가 준비되면 아래의 function을 불러올 것이다.
+						function onPlayerReady(event) {
+							event.target.playVideo();
+						}
+	
+						// 5. API는 플레이어의 상태가 변화될 때 아래의 function을 불러올 것이다.
+						//    이 function은 비디오가 재생되고 있을 때를 가르킨다.(state=1),
+						//    플레이어는 6초 이상 재생되고 정지되어야 한다.
+						var done = false;
+						function onPlayerStateChange(event) {
+							if (event.data == YT.PlayerState.PLAYING && !done) {
+								setTimeout(stopVideo, 6000);
+								done = true;
+							}
+						}
+						function stopVideo() {
+							player.stopVideo();
+						}
 				</script>
-
 			</td>
 		</tr>
 

--- a/src/main/webapp/WEB-INF/views/helppetf/petteacher/petteacher_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/helppetf/petteacher/petteacher_detail.jsp
@@ -34,10 +34,6 @@
 			<td>${dto.hpt_content }</td>
 		</tr>
 		<tr>
-			<td>URL</td>
-			<td>${dto.hpt_yt_url }</td>
-		</tr>
-		<tr>
 			<td>Video ID</td>
 			<td>${dto.hpt_yt_videoid }</td>
 		</tr>

--- a/src/main/webapp/WEB-INF/views/helppetf/petteacher/petteacher_main.jsp
+++ b/src/main/webapp/WEB-INF/views/helppetf/petteacher/petteacher_main.jsp
@@ -25,6 +25,7 @@
 			<th>번호</th>
 			<th>이름</th>
 			<th>제목</th>
+			<th>썸네일</th>
 			<th>설명</th>
 			<th>히트</th>
 		</tr>
@@ -34,6 +35,7 @@
 				<td>${y.hpt_exp }</td>
 				<td><a href="/helppetf/petteacher/petteacher_detail?hpt_seq=${y.hpt_seq }">
 						${y.hpt_title } </a></td>
+				<td><img src="https://i.ytimg.com/vi/${y.hpt_yt_videoid }/mqdefault.jpg" alt="썸네일" /></td>
 				<td>${y.hpt_rgedate }</td>
 				<td>${y.hpt_hit }</td>
 			</tr>

--- a/src/main/webapp/WEB-INF/views/include_jsp/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include_jsp/header.jsp
@@ -12,7 +12,7 @@
 	    <div class="menu_icons">
 	        <img src="<c:url value='/static/Images/MainImg/search_icon.png'/>" id="search_icon" alt="">
 	        <img src="<c:url value='/static/Images/MainImg/user_icon.png'/>" id="user_icon" alt="">
-	        <c:if test="${sessionScope.loginUser.mem_nick == 'admin'}">
+	        <c:if test="${sessionScope.loginUser.mem_nick eq 'admin'}">
 	    		<a href="<c:url value='/admin/home' />">
 	        	<img src="<c:url value='/static/Images/MainImg/admin_icon.png'/>" id="admin_icon" alt="관리자 아이콘">
 	   			</a>


### PR DESCRIPTION
페이징 기능 완성함. API요청을 할 때 한번에 80개의 데이터를 불러옴.
80개의 데이터를 한 페이지에 8개씩 10페이지로 나눠서 출력함 (최초의 요청시 1~10페이지 출력) "다음" 또는 "이전" 버튼을 눌러 다음 페이지그룹을 출력함 - 기존의 데이터 80개를 기준으로 이전 또는 다음의 80개 데이터를 출력함. (페이지는 이전, 다음 시 10개씩 변동) 필터링 기능 사용시 "다음"을 눌러 새 페이지그룹을 불러오더라도 필터링 유지됨.
기존 코드의 페이지 호출 시 API요청과 필터링이 있는 API요청이 나눠져 있던 것을 하나의 함수로 압축함

petteacher 기능 일부 수정 및 데이터베이스 테이블 일부 수정.
그에 따른 mapper(xml)의  구문 일부 수정 : 더 이상 유튜브 영상을 데이터베이스에 저장할 때 URL을 저장하지 않음.